### PR TITLE
Add admin login controller

### DIFF
--- a/genzo_turnstile.php
+++ b/genzo_turnstile.php
@@ -23,7 +23,7 @@ class Genzo_Turnstile extends Module
 	function __construct() {
 		$this->name = 'genzo_turnstile';
 		$this->tab = 'front_office_features';
-		$this->version = '1.1.0';
+                $this->version = '1.2.0';
 		$this->author = 'Emanuel Schiendorfer';
 		$this->need_instance = 1;
 
@@ -48,8 +48,9 @@ class Genzo_Turnstile extends Module
 	}
 
 	public function install() {
-		if (!parent::install() OR
-            !$this->registerHook('actionFrontControllerSetMedia')
+                if (!parent::install() ||
+            !$this->registerHook('actionFrontControllerSetMedia') ||
+            !$this->registerHook('actionAdminControllerSetMedia')
         ) {
             return false;
         }
@@ -224,6 +225,10 @@ class Genzo_Turnstile extends Module
         $this->validatePostValues();
     }
 
+    public function hookActionAdminControllerSetMedia() {
+        $this->validatePostValues();
+    }
+
     private function validatePostValues() {
 
         $turnstileActive = false;
@@ -313,6 +318,9 @@ class Genzo_Turnstile extends Module
             'AuthController' => [
                 'SubmitCreate' => 'CreateAccount',
                 'SubmitLogin' => 'Login',
+            ],
+            'AdminLoginController' => [
+                'submitLogin' => 'Login',
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- support Cloudflare Turnstile on Back Office login via AdminLoginController
- add admin controller media hook and bump module version

## Testing
- `php -l genzo_turnstile.php`

------
https://chatgpt.com/codex/tasks/task_e_68b8aa8d0c44832daf67c0560bdd4b30