### PR TITLE
Add admin login controller support

### DIFF
--- a/genzo_turnstile.php
+++ b/genzo_turnstile.php
@@ -47,15 +47,16 @@ class Genzo_Turnstile extends Module
         }
 	}
 
-	public function install() {
-		if (!parent::install() OR
-            !$this->registerHook('actionFrontControllerSetMedia')
+        public function install() {
+                if (!parent::install() OR
+            !$this->registerHook('actionFrontControllerSetMedia') OR
+            !$this->registerHook('actionAdminControllerSetMedia')
         ) {
             return false;
         }
 
-		return true;
-	}
+                return true;
+        }
 
 
 	// Backoffice
@@ -224,6 +225,10 @@ class Genzo_Turnstile extends Module
         $this->validatePostValues();
     }
 
+    public function hookActionAdminControllerSetMedia() {
+        $this->validatePostValues();
+    }
+
     private function validatePostValues() {
 
         $turnstileActive = false;
@@ -313,6 +318,9 @@ class Genzo_Turnstile extends Module
             'AuthController' => [
                 'SubmitCreate' => 'CreateAccount',
                 'SubmitLogin' => 'Login',
+            ],
+            'AdminLoginController' => [
+                'submitLogin' => 'AdminLogin',
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- register Turnstile scripts and validation for back office via `actionAdminControllerSetMedia`
- add AdminLogin controller rule so Turnstile can protect BO login

## Testing
- `php -l genzo_turnstile.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa8d0c44832daf67c0560bdd4b30