### PR TITLE
Add admin login controller support

### DIFF
--- a/genzo_turnstile.php
+++ b/genzo_turnstile.php
@@ -23,7 +23,7 @@ class Genzo_Turnstile extends Module
 	function __construct() {
 		$this->name = 'genzo_turnstile';
 		$this->tab = 'front_office_features';
-		$this->version = '1.1.0';
+                $this->version = '1.2.0';
 		$this->author = 'Emanuel Schiendorfer';
 		$this->need_instance = 1;
 
@@ -48,8 +48,9 @@ class Genzo_Turnstile extends Module
 	}
 
 	public function install() {
-		if (!parent::install() OR
-            !$this->registerHook('actionFrontControllerSetMedia')
+                if (!parent::install() OR
+            !$this->registerHook('actionFrontControllerSetMedia') OR
+            !$this->registerHook('actionAdminControllerSetMedia')
         ) {
             return false;
         }
@@ -224,6 +225,10 @@ class Genzo_Turnstile extends Module
         $this->validatePostValues();
     }
 
+    public function hookActionAdminControllerSetMedia() {
+        $this->validatePostValues();
+    }
+
     private function validatePostValues() {
 
         $turnstileActive = false;
@@ -313,6 +318,9 @@ class Genzo_Turnstile extends Module
             'AuthController' => [
                 'SubmitCreate' => 'CreateAccount',
                 'SubmitLogin' => 'Login',
+            ],
+            'AdminLoginController' => [
+                'submitLogin' => 'AdminLogin',
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- allow Turnstile to secure back office login by registering admin controller
- enable BO integration by providing AdminLoginController rule and media hook

## Testing
- `php -l genzo_turnstile.php`
- `node --check views/js/genzo_turnstile.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa8d0c44832daf67c0560bdd4b30